### PR TITLE
Set merge strategy per pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `strategy_override` field on the `PullRequest` table
+- New `set-merge-strategy` command on `pull-requests` to set an overriden merge strategy for a specific pull request
+- New `strategy+ <strategy>` and `strategy-` bot commands
+
 ### Changed
 
 - Replaced `structopt` with `argh`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ This README supposes the default bot handle: 'bot'.
 - `bot lock- <reason?>`: _Unlock a pull-request (unblock merge)_
 - `bot req+ <reviewers>`: _Assign required reviewers (you can assign multiple reviewers)_
 - `bot req- <reviewers>`: _Unassign required reviewers (you can unassign multiple reviewers)_
+- `bot strategy+ <strategy>`: _Override merge strategy for this pull request_
+- `bot strategy-`: _Remove the overriden merge strategy for this pull request_
 - `bot merge <merge|squash|rebase?>`: _Try merging the pull request with optional strategy_
 - `bot ping`: _Ping me_
 - `bot gif <search>`: _Post a random GIF with a tag_

--- a/crates/github_scbot_cli/src/commands/pull_request/mod.rs
+++ b/crates/github_scbot_cli/src/commands/pull_request/mod.rs
@@ -5,11 +5,13 @@ use stable_eyre::eyre::Result;
 use super::{Command, CommandContext};
 
 mod list;
+mod set_merge_strategy;
 mod show;
 mod sync;
 
 use self::{
-    list::PullRequestListCommand, show::PullRequestShowCommand, sync::PullRequestSyncCommand,
+    list::PullRequestListCommand, set_merge_strategy::PullRequestSetMergeStrategyCommand,
+    show::PullRequestShowCommand, sync::PullRequestSyncCommand,
 };
 
 /// manage pull requests.
@@ -32,6 +34,7 @@ impl Command for PullRequestCommand {
 pub(crate) enum PullRequestSubCommand {
     Show(PullRequestShowCommand),
     Sync(PullRequestSyncCommand),
+    SetMergeStrategy(PullRequestSetMergeStrategyCommand),
     List(PullRequestListCommand),
 }
 
@@ -42,6 +45,7 @@ impl Command for PullRequestSubCommand {
             Self::List(sub) => sub.execute(ctx).await,
             Self::Show(sub) => sub.execute(ctx).await,
             Self::Sync(sub) => sub.execute(ctx).await,
+            Self::SetMergeStrategy(sub) => sub.execute(ctx).await,
         }
     }
 }

--- a/crates/github_scbot_cli/src/commands/pull_request/set_merge_strategy.rs
+++ b/crates/github_scbot_cli/src/commands/pull_request/set_merge_strategy.rs
@@ -1,0 +1,59 @@
+use std::convert::TryFrom;
+
+use argh::FromArgs;
+use async_trait::async_trait;
+use github_scbot_types::pulls::GhMergeStrategy;
+use stable_eyre::eyre::Result;
+
+use crate::commands::{Command, CommandContext};
+
+/// list known pull request for a repository.
+#[derive(FromArgs)]
+#[argh(subcommand, name = "set-merge-strategy")]
+pub(crate) struct PullRequestSetMergeStrategyCommand {
+    /// repository path (e.g. 'MyOrganization/my-project')
+    #[argh(positional)]
+    repository_path: String,
+
+    /// pull request number.
+    #[argh(positional)]
+    number: u64,
+
+    /// merge strategy.
+    #[argh(positional)]
+    strategy: Option<String>,
+}
+
+#[async_trait(?Send)]
+impl Command for PullRequestSetMergeStrategyCommand {
+    async fn execute(self, ctx: CommandContext) -> Result<()> {
+        let strategy_enum = if let Some(s) = self.strategy {
+            Some(GhMergeStrategy::try_from(&s[..])?)
+        } else {
+            None
+        };
+
+        let (mut pr, _repo) = ctx
+            .db_adapter
+            .pull_request()
+            .get_from_repository_path_and_number(&self.repository_path, self.number)
+            .await?;
+
+        pr.set_strategy_override(strategy_enum);
+        ctx.db_adapter.pull_request().save(&mut pr).await?;
+
+        if let Some(s) = strategy_enum {
+            println!(
+                "Setting {:?} as a merge strategy override for pull request #{} on repository {}",
+                s, self.number, self.repository_path
+            );
+        } else {
+            println!(
+                "Removing merge strategy override for pull request #{} on repository {}",
+                self.number, self.repository_path
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/github_scbot_database/src/models/pulls/mod.rs
+++ b/crates/github_scbot_database/src/models/pulls/mod.rs
@@ -38,6 +38,7 @@ use builder::PullRequestModelBuilder;
     Default,
 )]
 #[table_name = "pull_request"]
+#[changeset_options(treat_none_as_null = "true")]
 pub struct PullRequestModel {
     /// Database ID.
     pub id: i32,
@@ -241,7 +242,7 @@ impl PullRequestModel {
 
     /// Get strategy override.
     pub fn get_strategy_override(&self) -> Option<GhMergeStrategy> {
-        self.step
+        self.strategy_override
             .as_ref()
             .and_then(|x| GhMergeStrategy::try_from(&x[..]).ok())
     }

--- a/crates/github_scbot_database/src/schema.rs
+++ b/crates/github_scbot_database/src/schema.rs
@@ -61,6 +61,7 @@ table! {
         locked -> Bool,
         merged -> Bool,
         closed -> Bool,
+        strategy_override -> Nullable<Varchar>,
     }
 }
 

--- a/crates/github_scbot_logic/src/commands/command.rs
+++ b/crates/github_scbot_logic/src/commands/command.rs
@@ -49,6 +49,10 @@ pub enum UserCommand {
     AssignRequiredReviewers(Vec<String>),
     /// Unassign required reviewers.
     UnassignRequiredReviewers(Vec<String>),
+    /// Set merge strategy.
+    SetMergeStrategy(GhMergeStrategy),
+    /// Unset merge strategy.
+    UnsetMergeStrategy,
     /// Add/Remove lock with optional reason.
     Lock(bool, Option<String>),
     /// Post a random gif.
@@ -204,6 +208,10 @@ impl Command {
             "req-" => Self::User(UserCommand::UnassignRequiredReviewers(
                 Self::parse_reviewers(args)?,
             )),
+            "strategy+" => Self::User(UserCommand::SetMergeStrategy(Self::parse_merge_strategy(
+                args,
+            )?)),
+            "strategy-" => Self::User(UserCommand::UnsetMergeStrategy),
             "gif" => Self::User(UserCommand::Gif(Self::parse_text(args))),
             "merge" => Self::User(UserCommand::Merge(Self::parse_optional_merge_strategy(
                 args,
@@ -317,6 +325,10 @@ impl Command {
                         "merge".into()
                     }
                 }
+                UserCommand::SetMergeStrategy(strategy) => {
+                    format!("strategy+ {}", strategy.to_string())
+                }
+                UserCommand::UnsetMergeStrategy => "strategy-".into(),
                 UserCommand::Ping => "ping".into(),
                 UserCommand::QaStatus(status) => format!("qa{}", Self::plus_minus_option(*status)),
                 UserCommand::SkipQaStatus(status) => {

--- a/crates/github_scbot_logic/src/commands/handlers.rs
+++ b/crates/github_scbot_logic/src/commands/handlers.rs
@@ -275,7 +275,7 @@ pub async fn handle_unset_merge_strategy(
 
     let comment = "Merge strategy override removed for this pull request.".into();
     Ok(CommandExecutionResult::builder()
-        .with_status_update(false)
+        .with_status_update(true)
         .with_action(ResultAction::AddReaction(GhReactionType::Eyes))
         .with_action(ResultAction::PostComment(comment))
         .build())

--- a/crates/github_scbot_logic/src/commands/handlers.rs
+++ b/crates/github_scbot_logic/src/commands/handlers.rs
@@ -260,6 +260,7 @@ pub async fn handle_set_merge_strategy(
         strategy
     );
     Ok(CommandExecutionResult::builder()
+        .with_status_update(true)
         .with_action(ResultAction::AddReaction(GhReactionType::Eyes))
         .with_action(ResultAction::PostComment(comment))
         .build())
@@ -274,6 +275,7 @@ pub async fn handle_unset_merge_strategy(
 
     let comment = "Merge strategy override removed for this pull request.".into();
     Ok(CommandExecutionResult::builder()
+        .with_status_update(false)
         .with_action(ResultAction::AddReaction(GhReactionType::Eyes))
         .with_action(ResultAction::PostComment(comment))
         .build())

--- a/crates/github_scbot_logic/src/commands/handlers.rs
+++ b/crates/github_scbot_logic/src/commands/handlers.rs
@@ -247,6 +247,38 @@ pub async fn handle_gif_command(
         .build())
 }
 
+pub async fn handle_set_merge_strategy(
+    db_adapter: &dyn IDatabaseAdapter,
+    pr_model: &mut PullRequestModel,
+    strategy: GhMergeStrategy,
+) -> Result<CommandExecutionResult> {
+    pr_model.set_strategy_override(Some(strategy));
+    db_adapter.pull_request().save(pr_model).await?;
+
+    let comment = format!(
+        "Merge strategy override set to '{:?}' for this pull request.",
+        strategy
+    );
+    Ok(CommandExecutionResult::builder()
+        .with_action(ResultAction::AddReaction(GhReactionType::Eyes))
+        .with_action(ResultAction::PostComment(comment))
+        .build())
+}
+
+pub async fn handle_unset_merge_strategy(
+    db_adapter: &dyn IDatabaseAdapter,
+    pr_model: &mut PullRequestModel,
+) -> Result<CommandExecutionResult> {
+    pr_model.set_strategy_override(None);
+    db_adapter.pull_request().save(pr_model).await?;
+
+    let comment = "Merge strategy override removed for this pull request.".into();
+    Ok(CommandExecutionResult::builder()
+        .with_action(ResultAction::AddReaction(GhReactionType::Eyes))
+        .with_action(ResultAction::PostComment(comment))
+        .build())
+}
+
 /// Handle `AssignRequiredReviewers` command.
 pub async fn handle_assign_required_reviewers_command(
     api_adapter: &dyn IAPIAdapter,
@@ -558,6 +590,8 @@ pub fn handle_help_command(
         - `lock- <reason?>`: _Unlock a pull-request (unblock merge)_\n\
         - `req+ <reviewers>`: _Assign required reviewers (you can assign multiple reviewers)_\n\
         - `req- <reviewers>`: _Unassign required reviewers (you can unassign multiple reviewers)_\n\
+        - `strategy+ <strategy>`: _Override merge strategy for this pull request_\n\
+        - `strategy-`: _Remove the overriden merge strategy for this pull request_\n\
         - `merge <merge|squash|rebase?>`: _Try merging the pull request with optional strategy_\n\
         - `ping`: _Ping me_\n\
         - `gif <search>`: _Post a random GIF with a tag_\n\

--- a/crates/github_scbot_logic/src/commands/mod.rs
+++ b/crates/github_scbot_logic/src/commands/mod.rs
@@ -277,6 +277,12 @@ impl CommandExecutor {
                         )
                         .await?
                     }
+                    UserCommand::SetMergeStrategy(strategy) => {
+                        handlers::handle_set_merge_strategy(db_adapter, pr_model, *strategy).await?
+                    }
+                    UserCommand::UnsetMergeStrategy => {
+                        handlers::handle_unset_merge_strategy(db_adapter, pr_model).await?
+                    }
                     UserCommand::UnassignRequiredReviewers(reviewers) => {
                         handlers::handle_unassign_required_reviewers_command(
                             api_adapter,

--- a/crates/github_scbot_logic/src/pulls.rs
+++ b/crates/github_scbot_logic/src/pulls.rs
@@ -371,13 +371,17 @@ pub async fn try_automerge_pull_request(
     pr_model: &PullRequestModel,
 ) -> Result<bool> {
     let commit_title = pr_model.get_merge_commit_title();
-    let strategy = MergeRuleModel::get_strategy_from_branches(
-        db_adapter.merge_rule(),
-        repo_model,
-        &pr_model.base_branch[..],
-        &pr_model.head_branch[..],
-    )
-    .await;
+    let strategy = if let Some(s) = pr_model.get_strategy_override() {
+        s
+    } else {
+        MergeRuleModel::get_strategy_from_branches(
+            db_adapter.merge_rule(),
+            repo_model,
+            &pr_model.base_branch[..],
+            &pr_model.head_branch[..],
+        )
+        .await
+    };
 
     if let Err(e) = api_adapter
         .pulls_merge(

--- a/crates/github_scbot_logic/src/status/pull_status.rs
+++ b/crates/github_scbot_logic/src/status/pull_status.rs
@@ -46,13 +46,17 @@ impl PullRequestStatus {
         pr_model: &PullRequestModel,
     ) -> Result<Self> {
         let reviews = pr_model.get_reviews(db_adapter.review()).await?;
-        let strategy = MergeRuleModel::get_strategy_from_branches(
-            db_adapter.merge_rule(),
-            repo_model,
-            &pr_model.base_branch[..],
-            &pr_model.head_branch[..],
-        )
-        .await;
+        let strategy = if let Some(s) = pr_model.get_strategy_override() {
+            s
+        } else {
+            MergeRuleModel::get_strategy_from_branches(
+                db_adapter.merge_rule(),
+                repo_model,
+                &pr_model.base_branch[..],
+                &pr_model.head_branch[..],
+            )
+            .await
+        };
 
         Self::from_pull_request(repo_model, pr_model, &reviews, strategy)
     }

--- a/docs/schema.plantuml
+++ b/docs/schema.plantuml
@@ -28,6 +28,7 @@ class PullRequest {
     locked: Boolean
     merged: Boolean
     closed: Boolean
+    strategy_override: String
 }
 
 class Review {

--- a/migrations/2021-09-29-130958_strategy_override/down.sql
+++ b/migrations/2021-09-29-130958_strategy_override/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pull_request DROP COLUMN strategy_override;

--- a/migrations/2021-09-29-130958_strategy_override/up.sql
+++ b/migrations/2021-09-29-130958_strategy_override/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pull_request ADD COLUMN strategy_override varchar(255);


### PR DESCRIPTION
### Added

- New `strategy_override` field on the `PullRequest` table
- New `set-merge-strategy` command on `pull-requests` to set an overriden merge strategy for a specific pull request
- New `strategy+ <strategy>` and `strategy-` bot commands